### PR TITLE
Add dependency: libssl-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Make sure you have the following dependencies:
 * sqlite3
 * libsqlite3-dev
 * openssl
+* libssl-dev
 
 [Install Rustup](https://doc.rust-lang.org/cargo/getting-started/installation.html) or Cargo.
 


### PR DESCRIPTION
Hi! 

First of all: I love the idea behind gourami 👏 

During a test installation on a debian system I was missing this dependency.