### PR TITLE
Implement RSS feed for a user

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ring",
+ "rss",
  "serde",
  "serde_json",
  "tokio",
@@ -1438,6 +1439,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick-xml"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe1e430bdcf30c9fdc25053b9c459bb1a4672af4617b6c783d7d91dc17c6bbb0"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,6 +1725,16 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "rss"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99979205510c60f80a119dedbabd0b8426517384edf205322f8bcd51796bcef9"
+dependencies = [
+ "derive_builder",
+ "quick-xml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ rand = "0.7.3"
 regex = "1.3.7"
 ring = "0.16.13"
 reqwest = {version="0.10.4",features=["json", "blocking"]}
+rss = "1.9.0"
 serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.52"
 tokio = { version = "0.2.18", features = ["macros", "time", "sync"] }

--- a/src/db/user.rs
+++ b/src/db/user.rs
@@ -62,17 +62,10 @@ impl User {
         )
         // remote url?
     }
-    pub fn authenticate(conn: &SqliteConnection, user: &str, pass: &str) -> Option<Self> {
-        use crate::db::schema::users::dsl::*;
+    pub fn authenticate(conn: &SqliteConnection, username: &str, pass: &str) -> Option<Self> {
         // TODO -- allow email login as well
-        debug!("Authenticating user {}", user);
-        let user = match users.filter(username.eq(user)).first::<Self>(conn) {
-            Ok(user) => user,
-            Err(e) => {
-                error!("Failed to load hash for {:?}: {:?}", user, e);
-                return None;
-            }
-        };
+        debug!("Authenticating user {}", username);
+        let user = Self::with_username(conn, username)?;
 
         let u_pass = match &user.password {
             Some(p) => p,
@@ -85,6 +78,17 @@ impl User {
             Err(e) => {
                 error!("Verify failed for {:?}: {:?}", user, e);
                 None
+            }
+        }
+    }
+
+    pub fn with_username(conn: &SqliteConnection, user_name: &str) -> Option<Self> {
+        use crate::db::schema::users::dsl::*;
+        match users.filter(username.eq(user_name)).first::<Self>(conn) {
+            Ok(user) => Some(user),
+            Err(e) => {
+                error!("Failed to load hash for {:?}: {:?}", username, e);
+                return None;
             }
         }
     }

--- a/src/db/user.rs
+++ b/src/db/user.rs
@@ -5,6 +5,8 @@ use diesel::sqlite::SqliteConnection;
 use serde::Deserialize;
 use std::env;
 
+use crate::ap::SERVER;
+
 #[derive(Debug, Clone, Default, Queryable, Deserialize)]
 pub struct RegistrationKey {
     value: String,
@@ -57,7 +59,7 @@ impl User {
     pub fn get_url(&self) -> String {
         format!(
             "{}/user/{}",
-            env::var("GOURAMI_DOMAIN").unwrap(),
+            SERVER.global_id,
             self.username
         )
         // remote url?

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@ pub enum Error {
     PoolError(r2d2::Error),
     MiscError(String), // Just a temp
     HttpSigError(http_signature_normalization::PrepareVerifyError),
+    RssError(rss::Error),
     UrlParseError(url::ParseError),
 }
 
@@ -50,5 +51,11 @@ impl From<serde_json::Error> for Error {
 impl From<http_signature_normalization::PrepareVerifyError> for Error {
     fn from(err: http_signature_normalization::PrepareVerifyError) -> Error {
         Error::HttpSigError(err)
+    }
+}
+
+impl From<rss::Error> for Error {
+    fn from(err: rss::Error) -> Error {
+        Error::RssError(err)
     }
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -81,6 +81,12 @@ pub async fn run_server() {
         .and(path::full())
         .map(user_page);
 
+    let user_feed = session_filter()
+        .and(path!("user" / String / "feed.rss"))
+        .and(query())
+        .and(path::full())
+        .map(user_feed);
+
     let user_edit_page = private_session_filter()
         .and(path!("user" / String / "edit"))
         .map(render_user_edit_page);
@@ -171,6 +177,7 @@ pub async fn run_server() {
     let html_renders = home
         .or(login_page)
         .or(register_page)
+        .or(user_feed)
         .or(user_page)
         .or(note_page)
         .or(server_info_page)

--- a/src/rss.rs
+++ b/src/rss.rs
@@ -1,0 +1,60 @@
+use std::collections::HashMap;
+use std::convert::{TryFrom, TryInto};
+
+use rss::{Channel, ChannelBuilder, GuidBuilder, ItemBuilder};
+
+use crate::{UserNote, PAGE_SIZE};
+use crate::db::note;
+use chrono::{DateTime, Utc};
+
+pub fn build_feed(title: String, description: String, link: String, notes: &[UserNote]) -> Result<Channel, String> {
+    let items = generate_rss_items(notes)?;
+    let mut namespaces = HashMap::new();
+    namespaces.insert(
+        "dc".to_string(),
+        "http://purl.org/dc/elements/1.1/".to_string(),
+    );
+
+    ChannelBuilder::default()
+        .namespaces(namespaces)
+        .title(title)
+        .link(link)
+        .description(description)
+        .items(items)
+        .build()
+}
+
+fn generate_rss_items(notes: &[UserNote]) -> Result<Vec<rss::Item>, String> {
+    notes
+        .iter()
+        .take(PAGE_SIZE as usize)
+        .map(|note| note.try_into())
+        .collect()
+}
+
+impl TryFrom<&UserNote> for rss::Item {
+    type Error = String;
+
+    fn try_from(user_note: &UserNote) -> Result<Self, Self::Error> {
+        let note = &user_note.note;
+        let guid = GuidBuilder::default()
+            .value(note::get_url(note.id))
+            .permalink(true)
+            .build()?;
+
+        let dc_extension = rss::extension::dublincore::DublinCoreExtensionBuilder::default()
+            .creators(vec![user_note.username.clone()])
+            .build()?;
+
+        let pub_date = DateTime::<Utc>::from_utc(note.created_time, Utc);
+        ItemBuilder::default()
+            .guid(Some(guid))
+            .title(note.content.clone())
+            .link(note::get_url(note.id))
+            .description(note.content.clone())
+            .pub_date(pub_date.to_rfc2822())
+            .dublin_core_ext(dc_extension)
+            .build()
+    }
+}
+


### PR DESCRIPTION
This PR implements an initial pass at RSS feeds for users. The feeds are located at `/user/<username>/feed.rss`. I haven't worked out how to add the `<link rel="alternate"` tag to allow autodiscovery of the feed, as it requires adding content to the `<head>` of the page. The generated RSS looks like this and passes the [Feed Validator](https://validator.w3.org/feed/):

```xml
<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
  <channel>
    <title>wezm - gourami</title>
    <link>http://localhost:3030/user/wezm</link>
    <description>New here!</description>
    <item>
      <title>Hi all! 👋</title>
      <link>http://localhost:3030/note/1</link>
      <description>
        <![CDATA[Hi all! 👋]]>
      </description>
      <guid>http://localhost:3030/note/1</guid>
      <pubDate>Mon, 01 Jun 2020 03:11:48 +0000</pubDate>
      <dc:creator>wezm</dc:creator>
    </item>
  </channel>
</rss>
```

It should be relatively straightforward for me to add the other feeds once you're happy with this one.

Relates to #5 